### PR TITLE
Allow multiple client request for history trace in debugguer

### DIFF
--- a/sources/appsgate-project/communication-components/TraceMan/src/main/java/appsgate/lig/ehmi/trace/TraceMan.java
+++ b/sources/appsgate-project/communication-components/TraceMan/src/main/java/appsgate/lig/ehmi/trace/TraceMan.java
@@ -446,7 +446,7 @@ public class TraceMan implements TraceManSpec {
             requestResult.put("result", result);
             requestResult.put("request", request);
 
-            EHMIProxy.sendFromConnection(DEBUGGER_COX_NAME, requestResult.toString());
+            EHMIProxy.sendFromConnection(DEBUGGER_COX_NAME, request.getInt("clientId"), requestResult.toString());
             
         } catch (JSONException e) {
             e.printStackTrace();


### PR DESCRIPTION
Now several clients can make requests simultaneously without collision in return
data.
History trace mode become unicast but livetrace stay global and broadcasted.
